### PR TITLE
remove - on julia version in REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.3-
+julia 0.3
 AbstractDomains
 BinDeps
 Docile


### PR DESCRIPTION
this means prereleases of julia 0.3, which has not been necessary for nearly a year
