### PR TITLE
Add Compat explicitly to REQUIRE, don't use Pkg.dir

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,5 @@
 julia 0.4
 AbstractDomains
+Compat
 BinDeps
 MathProgBase

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -4,7 +4,7 @@ extension = @osx? "zip" : "tar.gz"
 
 file_name = "dReal-$version-$os_string-shared-libs.$extension"
 file_url = "https://github.com/dreal/dreal3/releases/download/v$version/$file_name"
-deps_dir = joinpath(joinpath(Pkg.dir("DReal"),"deps"))
+deps_dir = dirname(@__FILE__)
 prefix = joinpath(deps_dir,"usr")
 
 

--- a/src/DReal.jl
+++ b/src/DReal.jl
@@ -13,7 +13,7 @@ using MathProgBase
 #     error("DReal not properly installed. Please run Pkg.build(\"DReal\")")
 # end
 
-deps_dir = joinpath(joinpath(Pkg.dir("DReal"),"deps"))
+deps_dir = joinpath(dirname(dirname(@__FILE__)),"deps")
 prefix = joinpath(deps_dir,"usr")
 src_dir = joinpath(prefix,"src")
 bin_dir = joinpath(prefix,"bin")


### PR DESCRIPTION
instead of assuming Compat will be present as an indirect dependency, and that the package can only be installed inside the package directory
